### PR TITLE
feat(header): allow "Contato" to open contact modal

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -19,7 +19,11 @@ export default function Home() {
   return (
     <>
       <Capa />
-      <Cabecalho />
+      <Cabecalho
+        openModal={() => {
+          setIsModalOpen(true);
+        }}
+      />
       <SectionTitle
         content="Meus Projetos"
       />

--- a/src/components/commons/Cabecalho/index.js
+++ b/src/components/commons/Cabecalho/index.js
@@ -1,20 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Box from '../../foundation/layout/Box';
 import Text from '../../foundation/Text';
 import CabecalhoWrapper from './styles';
 
-export default function Cabecalho() {
-  const links = [
-    {
-      text: 'Sobre mim',
-      url: '/about-me',
-    },
-    {
-      text: 'Contato',
-      url: '/contact',
-    },
-  ];
-
+export default function Cabecalho({ openModal }) {
   return (
     <Box
       width="100%"
@@ -35,24 +25,36 @@ export default function Cabecalho() {
             href="/"
             color="primary.main"
           >
-            &lt;me/&gt;
+            &lt;danicaus/&gt;
           </Text>
         </CabecalhoWrapper.LeftSide>
         <CabecalhoWrapper.RightSide>
-          {links.map((link) => (
-            <li key={link.url}>
-              <Text
-                variant="navBar"
-                tag="a"
-                href={link.url}
-                color="primary.main"
-              >
-                {link.text}
-              </Text>
-            </li>
-          ))}
+          <li>
+            <Text
+              variant="navBar"
+              tag="a"
+              href="/about-me"
+              color="primary.main"
+            >
+              Sobre mim
+            </Text>
+          </li>
+          <li>
+            <Text
+              variant="navBar"
+              tag="button"
+              onClick={openModal}
+              color="primary.main"
+            >
+              Contato
+            </Text>
+          </li>
         </CabecalhoWrapper.RightSide>
       </CabecalhoWrapper>
     </Box>
   );
 }
+
+Cabecalho.propTypes = {
+  openModal: PropTypes.func.isRequired,
+};

--- a/src/components/commons/Cabecalho/styles/index.js
+++ b/src/components/commons/Cabecalho/styles/index.js
@@ -32,11 +32,11 @@ CabecalhoWrapper.LeftSide = styled.div`
   padding: 11px;
   ${breakpointsMedia({
     xs: css`
-      width: 83px;
+      width: auto;
       height: 40px;
       `,
     md: css`
-      width: 136px;
+      width: auto;
       height: 67px;
     `,
   })}

--- a/src/components/foundation/Text/index.js
+++ b/src/components/foundation/Text/index.js
@@ -107,6 +107,8 @@ const mapTypographyVariants = {
 const TextBase = styled.span`
   margin: 0;
   padding: 0;
+  background-color: transparent;
+  border: none;
   ${({ variant }) => mapTypographyVariants[variant]}
   color: ${({ theme, color }) => get(theme, `colors.${color}.color`)};
   font-family: ${({ theme, font }) => get(theme, `fontFamilies.${font}`)};

--- a/src/theme/GlobalStyle.js
+++ b/src/theme/GlobalStyle.js
@@ -25,6 +25,10 @@ const GlobalStyle = createGlobalStyle`
   li {
     list-style: none;
   }
+
+  button {
+    cursor: pointer;
+  }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
This commit changes the header. I transformed the "contato" from anchor to a button, but it's still
a Text component. For that, I added transparent background and removed border for all Text
components, what didn't affect the other ones. I also added the pointer behavior globally for all
buttons. I decided that strategy because the current buttons are rounded and have very specific
style. Maybe I'll reconsider that in the future.