### PR TITLE
refactor(architecture): create general components with repetitive parts of the code

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -1,59 +1,10 @@
-import React from 'react';
-import Cabecalho from '../src/components/commons/Cabecalho';
-import Footer from '../src/components/commons/Footer';
-import Box from '../src/components/foundation/layout/Box';
-import Text from '../src/components/foundation/Text';
+import ErrorScreen from '../src/components/screens/ErrorScreen';
+import websitePageHOC from '../src/components/wrappers/WebSitePage/hoc';
 
-export default function ErrorPage() {
-  return (
-    <Box
-      height="100vh"
-      display="flex"
-      flexDirection="column"
-      justifyContent="space-between"
-    >
-      <Cabecalho />
-      <Box
-        backgroundImage="linear-gradient(#002d4aaa, #002d4aaa), url(./images/mergulho.png)"
-        backgroundRepeat="no-repeat"
-        backgroundPosition="bottom left"
-        backgroundSize="cover"
-        display="flex"
-        alignItems="center"
-        position="absolute"
-        top="0"
-        left="0"
-        right="0"
-        bottom="0"
-        zIndex="-1"
-      >
-        <Box
-          display="block"
-          width={{
-            xs: '100%',
-            md: '50%',
-          }}
-        >
-          <Text
-            tag="h1"
-            variant="title"
-            color="tertiary.main"
-            textAlign="center"
-          >
-            404
-          </Text>
-          <Text
-            tag="h2"
-            variant="subTitle"
-            color="tertiary.main"
-            textAlign="center"
-          >
-            Página Não Encontrada
-          </Text>
-        </Box>
-
-      </Box>
-      <Footer />
-    </Box>
-  );
-}
+export default websitePageHOC(ErrorScreen, {
+  pageWrapperProps: {
+    boxProps: {
+      height: '100vh',
+    },
+  },
+});

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import Head from 'next/head';
-import { ThemeProvider } from 'styled-components';
 import PropTypes from 'prop-types';
-import theme from '../src/theme';
-import GlobalStyle from '../src/theme/GlobalStyle';
 
 export default function App({ Component, pageProps }) {
   return (
@@ -13,11 +10,8 @@ export default function App({ Component, pageProps }) {
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
         <link href="https://fonts.googleapis.com/css2?family=Fira+Sans&family=Fira+Sans+Condensed:wght@300;400;700&display=swap" rel="stylesheet" />
       </Head>
-      <ThemeProvider theme={theme}>
-        <GlobalStyle />
-        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-        <Component {...pageProps} />
-      </ThemeProvider>
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <Component {...pageProps} />
     </>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,91 +1,12 @@
-import React, { useState } from 'react';
-import Cabecalho from '../src/components/commons/Cabecalho';
-import Capa from '../src/components/commons/Capa';
-import Card from '../src/components/commons/Card';
-import Button from '../src/components/foundation/layout/Button';
-import Footer from '../src/components/commons/Footer';
-import SectionTitle from '../src/components/commons/SectionTitle';
-import WrapperProjetos from '../src/components/wrappers/WrapperProjetos';
-import projetos from '../src/content/Projects';
-import Text from '../src/components/foundation/Text';
-import Box from '../src/components/foundation/layout/Box';
-import ContactFormWrapper from '../src/components/commons/ContactForm';
-import Modal from '../src/components/commons/Modal';
-import Link from '../src/components/commons/Link';
+import HomeScreen from '../src/components/wrappers/HomeScreen';
+import websitePageHOC from '../src/components/wrappers/WebSitePage/hoc';
 
-export default function Home() {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  return (
-    <>
-      <Capa />
-      <Cabecalho
-        openModal={() => {
-          setIsModalOpen(true);
-        }}
-      />
-      <SectionTitle
-        content="Meus Projetos"
-      />
-      <WrapperProjetos>
-        {projetos.map((projeto) => (
-          <Link href={`/project/${projeto.slug}`}>
-            <Card
-              key={projeto.id}
-              infoProjeto={projeto}
-            />
-          </Link>
-        ))}
-      </WrapperProjetos>
-      <Box
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        justifyContent="center"
-        margin="0 0 46px 0"
-      >
-        <Text
-          tag="h2"
-          variant="getInTouchTitle"
-          color="tertiary.main"
-        >
-          Entre em contato
-        </Text>
-        <Button
-          margin={{
-            xs: '12px 0 0 0',
-            md: '8px 0 0 0',
-          }}
-          onClick={() => {
-            setIsModalOpen(!isModalOpen);
-          }}
-        >
-          <Text
-            tag="p"
-            variant="cardTitle"
-            color="tertiary.main"
-            font="firaRegular"
-          >
-            +
-          </Text>
-        </Button>
-      </Box>
-      <Modal
-        isOpen={isModalOpen}
-        onClose={() => {
-          setIsModalOpen(false);
-        }}
-      >
-        {(propsDoModal) => (
-          <ContactFormWrapper
-            propsDoModal={propsDoModal}
-            onClose={() => {
-              setIsModalOpen(false);
-            }}
-          />
-        )}
-      </Modal>
-      <Footer />
-    </>
-  );
-}
+export default websitePageHOC(HomeScreen, {
+  pageWrapperProps: {
+    capaProps: {
+      display: true,
+      title: 'Daniela Caus',
+      subtitle: 'Portfólio Alura',
+    },
+  },
+});

--- a/src/components/commons/Capa/index.js
+++ b/src/components/commons/Capa/index.js
@@ -1,17 +1,19 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
+import PropTypes from 'prop-types';
 import Text from '../../foundation/Text';
 import Box from '../../foundation/layout/Box';
 
-export default function Capa() {
+export default function Capa({ title, subtitle, boxProps }) {
   return (
     <Box
-      backgroundImage="url(./images/mergulho.png)"
       backgroundRepeat="no-repeat"
       backgroundPosition="bottom left"
       backgroundSize="cover"
       height="100vh"
       display="flex"
       alignItems="center"
+      {...boxProps}
     >
       <Box
         display="block"
@@ -26,7 +28,7 @@ export default function Capa() {
           color="tertiary.main"
           textAlign="center"
         >
-          Daniela Caus
+          {title}
         </Text>
         <Text
           tag="h2"
@@ -34,10 +36,36 @@ export default function Capa() {
           color="tertiary.main"
           textAlign="center"
         >
-          Portfolio
+          {subtitle}
         </Text>
       </Box>
 
     </Box>
   );
 }
+
+Capa.propTypes = {
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+  boxProps: PropTypes.shape({
+    backgroundImage: PropTypes.string,
+    position: PropTypes.string,
+    top: PropTypes.string,
+    left: PropTypes.string,
+    right: PropTypes.string,
+    bottom: PropTypes.string,
+    zIndex: PropTypes.string,
+  }),
+};
+
+Capa.defaultProps = {
+  boxProps: {
+    backgroundImage: 'url(./images/mergulho.png)',
+    position: '',
+    top: '',
+    left: '',
+    right: '',
+    bottom: '',
+    zIndex: '',
+  },
+};

--- a/src/components/commons/Modal/index.js
+++ b/src/components/commons/Modal/index.js
@@ -13,6 +13,7 @@ const ModalWrapper = styled.div`
   left: 0;
   right: 0;
   bottom: 0; 
+  z-index: 5;
   ${({ isOpen }) => {
     if (isOpen) {
       return css`

--- a/src/components/screens/ErrorScreen/index.js
+++ b/src/components/screens/ErrorScreen/index.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Capa from '../../commons/Capa';
+
+export default function ErrorScreen() {
+  return (
+    <Capa
+      title="404"
+      subtitle="Página não encontrada"
+      boxProps={{
+        backgroundImage: 'linear-gradient(#002d4aaa, #002d4aaa), url(./images/mergulho.png)',
+        position: 'absolute',
+        top: '0',
+        left: '0',
+        right: '0',
+        bottom: '0',
+        zIndex: '-1',
+      }}
+    />
+  );
+}

--- a/src/components/wrappers/HomeScreen/index.js
+++ b/src/components/wrappers/HomeScreen/index.js
@@ -1,0 +1,63 @@
+import React, { useContext } from 'react';
+import projetos from '../../../content/Projects';
+import Card from '../../commons/Card';
+import Link from '../../commons/Link';
+import SectionTitle from '../../commons/SectionTitle';
+import Box from '../../foundation/layout/Box';
+import Button from '../../foundation/layout/Button';
+import Text from '../../foundation/Text';
+import { WebsitePageContext } from '../WebSitePage';
+import WrapperProjetos from '../WrapperProjetos';
+
+export default function HomeScreen() {
+  const toggleModal = useContext(WebsitePageContext);
+
+  return (
+    <>
+      <SectionTitle
+        content="Meus Projetos"
+      />
+      <WrapperProjetos>
+        {projetos.map((projeto) => (
+          <Link href={`/project/${projeto.slug}`}>
+            <Card
+              key={projeto.id}
+              infoProjeto={projeto}
+            />
+          </Link>
+        ))}
+      </WrapperProjetos>
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        margin="0 0 46px 0"
+      >
+        <Text
+          tag="h2"
+          variant="getInTouchTitle"
+          color="tertiary.main"
+        >
+          Entre em contato
+        </Text>
+        <Button
+          margin={{
+            xs: '12px 0 0 0',
+            md: '8px 0 0 0',
+          }}
+          onClick={() => toggleModal.toggleModalContato()}
+        >
+          <Text
+            tag="p"
+            variant="cardTitle"
+            color="tertiary.main"
+            font="firaRegular"
+          >
+            +
+          </Text>
+        </Button>
+      </Box>
+    </>
+  );
+}

--- a/src/components/wrappers/WebSitePage/hoc/index.js
+++ b/src/components/wrappers/WebSitePage/hoc/index.js
@@ -1,0 +1,22 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import WebsiteGlobalProvider from '../provider';
+import WebsitePageWrapper from '..';
+
+export default function websitePageHOC(
+  PageComponent,
+  { pageWrapperProps } = { pageWrapperProps: {} },
+) {
+  return (props) => (
+    <WebsiteGlobalProvider>
+      <WebsitePageWrapper
+        {...pageWrapperProps}
+        {...props.pageWrapperProps}
+      >
+        <PageComponent {...props} />
+      </WebsitePageWrapper>
+    </WebsiteGlobalProvider>
+  );
+}

--- a/src/components/wrappers/WebSitePage/index.js
+++ b/src/components/wrappers/WebSitePage/index.js
@@ -1,0 +1,84 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React, { createContext, useState } from 'react';
+import PropTypes from 'prop-types';
+import Cabecalho from '../../commons/Cabecalho';
+import ContactFormWrapper from '../../commons/ContactForm';
+import Footer from '../../commons/Footer';
+import Modal from '../../commons/Modal';
+import Box from '../../foundation/layout/Box';
+import Capa from '../../commons/Capa';
+
+export const WebsitePageContext = createContext({
+  toggleModalContato: () => {},
+});
+
+export default function WebsitePageWrapper({
+  children,
+  boxProps,
+  capaProps,
+}) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  return (
+    <WebsitePageContext.Provider
+      value={{
+        toggleModalContato: () => {
+          setIsModalOpen(!isModalOpen);
+        },
+      }}
+    >
+      <Box
+        display="flex"
+        flex="1"
+        flexDirection="column"
+        justifyContent="space-between"
+        {...boxProps}
+      >
+        {capaProps.display && <Capa title={capaProps.title} subtitle={capaProps.subtitle} />}
+        <Cabecalho
+          openModal={() => {
+            setIsModalOpen(true);
+          }}
+        />
+        <Modal
+          isOpen={isModalOpen}
+          onClose={() => {
+            setIsModalOpen(false);
+          }}
+        >
+          {(propsDoModal) => (
+            <ContactFormWrapper
+              propsDoModal={propsDoModal}
+              onClose={() => {
+                setIsModalOpen(false);
+              }}
+            />
+          )}
+        </Modal>
+        {children}
+        <Footer />
+      </Box>
+    </WebsitePageContext.Provider>
+  );
+}
+
+WebsitePageWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+  boxProps: PropTypes.shape({
+    height: PropTypes.string,
+  }),
+  capaProps: PropTypes.shape({
+    display: PropTypes.bool,
+    title: PropTypes.string.isRequired,
+    subtitle: PropTypes.string.isRequired,
+  }),
+};
+
+WebsitePageWrapper.defaultProps = {
+  boxProps: {
+    height: '',
+  },
+  capaProps: {
+    display: false,
+  },
+};

--- a/src/components/wrappers/WebSitePage/provider/index.js
+++ b/src/components/wrappers/WebSitePage/provider/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ThemeProvider } from 'styled-components';
+import theme from '../../../../theme';
+import GlobalStyle from '../../../../theme/GlobalStyle';
+
+export default function WebsiteGlobalProvider({ children }) {
+  return (
+    <ThemeProvider theme={theme}>
+      <GlobalStyle />
+      {children}
+    </ThemeProvider>
+  );
+}
+
+WebsiteGlobalProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};


### PR DESCRIPTION
Created some components to avoid repetitive parts of components between pages. WebsitePageWrapper
contains header, footer and modal, that exists on almost all pages. WebsiteGlobalProvider contains
theme provider and global style. WebsitePageHOC is a function used on all pages and contains globa
props and providers. Once this components were created, I nedded to adapt other components like
Home, adding a HomeScreen component. It also allowed to adapt Capa so it could be used on Home and
404 pages. I also could remove theme providers and globalStyles from _app file..