### PR TITLE
feat(projectpage): create project page using getStaticPaths

### DIFF
--- a/pages/project/[project].js
+++ b/pages/project/[project].js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ProjectScreen from '../../src/components/screens/ProjectScreen';
+import websitePageHOC from '../../src/components/wrappers/WebSitePage/hoc';
+import projetos from '../../src/content/Projects';
+
+function ProjectPage({ project }) {
+  return (
+    <ProjectScreen projeto={project} />
+  );
+}
+
+export default websitePageHOC(ProjectPage);
+
+export function getStaticProps({ params }) {
+  const projectContent = projetos.find((projeto) => {
+    if (projeto.slug === params.project) {
+      return true;
+    }
+    return false;
+  });
+
+  return {
+    props: {
+      project: projectContent,
+    },
+  };
+}
+
+export function getStaticPaths() {
+  const paths = projetos.map((projeto) => (
+    { params: { project: projeto.slug } }
+  ));
+
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+ProjectPage.propTypes = {
+  project: PropTypes.shape({
+    id: PropTypes.number,
+    image: PropTypes.string,
+    imageNext: PropTypes.string,
+    url: PropTypes.string,
+    title: PropTypes.string,
+    slug: PropTypes.string,
+    highlight: PropTypes.bool,
+    description: PropTypes.string,
+  }).isRequired,
+};

--- a/src/components/foundation/Text/index.js
+++ b/src/components/foundation/Text/index.js
@@ -116,6 +116,7 @@ const TextBase = styled.span`
   ${propToStyle('marginTop')}
   ${propToStyle('marginBottom')}
   ${propToStyle('transform')};
+  ${propToStyle('fontWeight')};
 `;
 
 function Text({

--- a/src/components/foundation/layout/Box/index.js
+++ b/src/components/foundation/layout/Box/index.js
@@ -6,6 +6,7 @@ const Box = styled.div`
   ${propToStyle('height')};
   ${propToStyle('width')};
   ${propToStyle('maxWidth')};
+  ${propToStyle('minHeight')};
   ${propToStyle('top')};
   ${propToStyle('left')};
   ${propToStyle('right')};
@@ -21,6 +22,7 @@ const Box = styled.div`
   ${propToStyle('display')};
   ${propToStyle('flexDirection')};
   ${propToStyle('flexWrap')};
+  ${propToStyle('flex')};
   ${propToStyle('alignItems')};
   ${propToStyle('justifyContent')};
   ${propToStyle('order')};

--- a/src/components/screens/ProjectScreen/index.js
+++ b/src/components/screens/ProjectScreen/index.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Image from 'next/image';
+import SectionTitle from '../../commons/SectionTitle';
+import Box from '../../foundation/layout/Box';
+import Text from '../../foundation/Text';
+
+export default function ProjectScreen({ projeto }) {
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      flex="1"
+    >
+      <SectionTitle
+        content={projeto.title}
+      />
+      <Box
+        display="flex"
+        gap={{
+          xs: '62px',
+          md: '42px',
+        }}
+        flexDirection={{
+          xs: 'column',
+          md: 'row',
+        }}
+        margin={{
+          xs: '0 0 36px',
+          md: '0 auto 92px',
+        }}
+        padding="0 16px"
+      >
+        <Box
+          width={{
+            xs: '100%',
+            md: '500px',
+          }}
+          height={{
+            xs: '200px',
+            md: '300px',
+          }}
+          border="1px solid"
+          borderColor="borders.secondary"
+          position="relative"
+          backgroundColor="background.light"
+        >
+          <Image src={projeto.imageNext} layout="fill" objectFit="cover" />
+        </Box>
+        <Box
+          maxWidth={{
+            xs: '100%',
+            md: '500px',
+          }}
+        >
+          <Text
+            tag="p"
+            variant="paragraph"
+            color="tertiary.main"
+          >
+            {projeto.description}
+          </Text>
+          <Text
+            tag="p"
+            variant="paragraph"
+            color="tertiary.main"
+            fontWeight="700"
+            marginTop={{
+              xs: '36px',
+              md: '63px',
+            }}
+            marginBottom="16px"
+          >
+            Visite o site
+          </Text>
+          <Text
+            tag="a"
+            href={projeto.url}
+            variant="paragraph"
+            color="secondary.main"
+          >
+            {projeto.url}
+          </Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+ProjectScreen.propTypes = {
+  projeto: PropTypes.shape({
+    id: PropTypes.number,
+    image: PropTypes.string,
+    imageNext: PropTypes.string,
+    url: PropTypes.string,
+    title: PropTypes.string,
+    slug: PropTypes.string,
+    highlight: PropTypes.bool,
+    description: PropTypes.string,
+  }).isRequired,
+};

--- a/src/components/wrappers/WebSitePage/index.js
+++ b/src/components/wrappers/WebSitePage/index.js
@@ -31,7 +31,7 @@ export default function WebsitePageWrapper({
         display="flex"
         flex="1"
         flexDirection="column"
-        justifyContent="space-between"
+        minHeight="100vh"
         {...boxProps}
       >
         {capaProps.display && <Capa title={capaProps.title} subtitle={capaProps.subtitle} />}

--- a/src/content/Projects/index.js
+++ b/src/content/Projects/index.js
@@ -2,6 +2,8 @@ const projetos = [
   {
     id: 1,
     image: 'url(./images/project-example-1.png)',
+    imageNext: '/images/project-example-1.png',
+    url: 'https://instalura-danicaus.vercel.app/',
     title: 'Projeto um',
     slug: 'projeto-um',
     highlight: false,
@@ -10,6 +12,8 @@ const projetos = [
   {
     id: 2,
     image: 'url(./images/project-example-2.png)',
+    imageNext: '/images/project-example-2.png',
+    url: 'https://instalura-danicaus.vercel.app/',
     title: 'Projeto dois',
     slug: 'projeto-dois',
     highlight: false,
@@ -18,6 +22,8 @@ const projetos = [
   {
     id: 3,
     image: 'url(./images/project-example-1.png)',
+    imageNext: '/images/project-example-1.png',
+    url: 'https://instalura-danicaus.vercel.app/',
     title: 'Projeto três',
     slug: 'projeto-tres',
     highlight: false,
@@ -26,6 +32,8 @@ const projetos = [
   {
     id: 4,
     image: 'url(./images/project-example-2.png)',
+    imageNext: '/images/project-example-2.png',
+    url: 'https://instalura-danicaus.vercel.app/',
     title: 'Projeto quatro',
     slug: 'projeto-quatro',
     highlight: true,


### PR DESCRIPTION
This commit creates each project's page, using Next's getStaticPaths resource. I used Next's Image
component to display the images, and that obligated me to create a new field on Projects'array. As
the layout asked for a url, I also added this atribute to Projects' array. The page got really few
content, so the Footer ended before the page. That's why I changed sime style behaviors of
WebsitePageWrapper to have a minHeight.